### PR TITLE
Sample will only run with -conf

### DIFF
--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -76,7 +76,7 @@
                                         <!--
                                         <Main-Verticle>com.github.mcollovati.vertx.vaadin.sample.PushTestUI$MyVerticle</Main-Verticle>
                                         -->
-                                        <Main-Verticle>com.github.mcollovati.vertx.vaadin.VaadinVerticle</Main-Verticle>
+                                        <Main-Verticle>com.github.mcollovati.vertx.vaadin.sample.SimpleVerticle</Main-Verticle>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>


### PR DESCRIPTION
pom.xml declared VaadinVerticle instead of SimpleVerticle, causing annotations on SimpleVerticle to be ignored